### PR TITLE
Make emoji bigger to more closely resemble Discord

### DIFF
--- a/zulip.css
+++ b/zulip.css
@@ -153,3 +153,8 @@ body > .header {
 ::-webkit-scrollbar-track {
     margin-bottom: 8px;
 }
+
+.rendered_markdown .emoji {
+    width: 36px !important;
+    height: 36px !important;
+}


### PR DESCRIPTION
Discord Emoji's vary in size, however this size is a good middleground and makes all emojis in Zulip more readable